### PR TITLE
Fix for Deprecated Transfer Operator Functions

### DIFF
--- a/alfi/driver.py
+++ b/alfi/driver.py
@@ -119,7 +119,7 @@ def run_solver(solver, res, args):
                 with DumbCheckpoint(chkptdir + "nssolution-Re-%s" % (re), mode=FILE_UPDATE) as checkpoint:
                     checkpoint.store(solver.z, name="up_%i" % re)
         if args.paraview:
-            pvdf.write(solver.visprolong(solver.z.split()[0]), time=re)
+            pvdf.write(solver.visprolong(solver.z.subfunctions[0]), time=re)
 
     if comm.rank == 0:
         for re in results:

--- a/alfi/solver.py
+++ b/alfi/solver.py
@@ -171,8 +171,8 @@ class NavierStokesSolver(object):
         if comm.rank == 0:
             print("Number of velocity degrees of freedom: %s (avg %.2f per core)" % (Vdim, Vdim / size))
         z = Function(Z, name="Solution")
-        z.split()[0].rename("Velocity")
-        z.split()[1].rename("Pressure")
+        z.subfunctions[0].rename("Velocity")
+        z.subfunctions[1].rename("Pressure")
         self.z = z
         (u, p) = split(z)
         (v, q) = split(TestFunction(Z))
@@ -268,14 +268,14 @@ class NavierStokesSolver(object):
         # self.gamma.assign(1+re)
 
         if self.stabilisation is not None:
-            self.stabilisation.update(self.z.split()[0])
+            self.stabilisation.update(self.z.subfunctions[0])
         start = datetime.now()
         self.solver.solve()
         end = datetime.now()
 
         if self.nsp is not None:
             # Hardcode that pressure integral is zero
-            (u, p) = self.z.split()
+            (u, p) = self.z.subfunctions
             pintegral = assemble(p*dx)
             p.assign(p - Constant(pintegral/self.area))
 

--- a/alfi/solver.py
+++ b/alfi/solver.py
@@ -115,7 +115,9 @@ class NavierStokesSolver(object):
         self.parallel = mh[0].comm.size > 1
         self.tdim = mh[0].topological_dimension()
         self.mh = mh
-        self.area = assemble(Constant(1, domain=mh[0])*dx)
+        p_const = Function(FunctionSpace(mh[0], 'Real', 0))
+        p_const.assign(1)
+        self.area = assemble(p_const*dx)
         nu = Constant(1.0)
         self.nu = nu
         self.char_L = problem.char_length()

--- a/alfi/transfer.py
+++ b/alfi/transfer.py
@@ -272,9 +272,9 @@ class AutoSchoeberlTransfer(object):
             # solver.solve(rhs, fine)
             b = assemble(bform, tensor=b)
             # rhs.assign(fine-b)
-            rhs.dat.data[:] = fine.dat.data_ro - b.dat.data_ro
-            self.standard_transfer(rhs, coarse, "restrict")
-
+            rhs_cofunc = Cofunction(V.dual())
+            rhs_cofunc.dat.data[:] = fine.dat.data_ro - b.dat.data_ro
+            self.standard_transfer(rhs_cofunc, coarse, "restrict")
 
         # def energy_norm(u):
         #     return assemble(action(action(self.form(u.function_space()), u), u))


### PR DESCRIPTION
I've addressed a transfer operator setup error in Alfi, discovered after the recent cofunction coarsening merge and while using Firedrake version 0.13.0+5915.g4a89a725e. The error, detailed below, occurred with this specific command:
```
python ldc2d.py --baseN 4 --k 3 --solver-type almg --discretisation sv --mh bary --patch macro --smoothing 10 --restriction
```
Error:
```
Traceback (most recent call last):
  File "/home/alex/alfi/examples/ldc2d/ldc2d.py", line 57, in <module>
    results = run_solver(solver, res, args)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/alfi/alfi/driver.py", line 116, in run_solver
    (z, info_dict) = solver.solve(re)
                     ^^^^^^^^^^^^^^^^
  File "/home/alex/alfi/alfi/solver.py", line 273, in solve
    self.solver.solve()
  File "petsc4py/PETSc/Log.pyx", line 188, in petsc4py.PETSc.Log.EventDecorator.decorator.wrapped_func
  File "petsc4py/PETSc/Log.pyx", line 189, in petsc4py.PETSc.Log.EventDecorator.decorator.wrapped_func
  File "/home/alex/firedrake/src/firedrake/firedrake/adjoint_utils/variational_solver.py", line 89, in wrapper
    out = solve(self, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex/firedrake/src/firedrake/firedrake/variational_solver.py", line 288, in solve
    self.snes.solve(None, work)
  File "petsc4py/PETSc/SNES.pyx", line 1555, in petsc4py.PETSc.SNES.solve
  File "petsc4py/PETSc/PETSc.pyx", line 323, in petsc4py.PETSc.PetscPythonErrorHandler
  File "petsc4py/PETSc/PETSc.pyx", line 323, in petsc4py.PETSc.PetscPythonErrorHandler
  File "petsc4py/PETSc/PETSc.pyx", line 323, in petsc4py.PETSc.PetscPythonErrorHandler
  [Previous line repeated 14 more times]
  File "petsc4py/PETSc/libpetsc4py.pyx", line 789, in petsc4py.PETSc.MatMultTranspose_Python
  File "/home/alex/firedrake/src/firedrake/firedrake/mg/ufl_utils.py", line 368, in multTranspose
    self.manager.restrict(self.fdual, self.cdual)
  File "/home/alex/firedrake/src/firedrake/firedrake/mg/embedded.py", line 300, in restrict
    self._native_transfer(source_element, Op.RESTRICT)(source, target)
  File "<decorator-gen-33>", line 2, in restrict
  File "/home/alex/firedrake/src/PyOP2/pyop2/profiling.py", line 60, in wrapper
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/home/alex/alfi/alfi/transfer.py", line 193, in restrict
    self.restrict_or_prolong(fine, coarse, "restrict")
  File "/home/alex/alfi/alfi/transfer.py", line 277, in restrict_or_prolong
    self.standard_transfer(rhs, coarse, "restrict")
  File "/home/alex/alfi/alfi/transfer.py", line 291, in standard_transfer
    restrict(source, target)
  File "petsc4py/PETSc/Log.pyx", line 188, in petsc4py.PETSc.Log.EventDecorator.decorator.wrapped_func
  File "petsc4py/PETSc/Log.pyx", line 189, in petsc4py.PETSc.Log.EventDecorator.decorator.wrapped_func
  File "/home/alex/firedrake/src/firedrake/firedrake/mg/interface.py", line 98, in restrict
    check_arguments(coarse_dual, fine_dual, needs_dual=True)
  File "/home/alex/firedrake/src/firedrake/firedrake/mg/interface.py", line 20, in check_arguments
    raise TypeError("Fine argument is a %s, not a %s" % (type(fine).__name__, expected_type.__name__))
TypeError: Fine argument is a Function, not a Cofunction
```

With assistance from @pefarrell, we identified that passing Confunction to Firedrake's restriction/interpolation functions resolves this issue. Additionally, I've corrected several function calls to eliminate deprecation warnings. The only remaining warning concerns the DumbCheckpoint class, suggested for replacement with CheckpointFile. I leave this particular deprecation to the authors' discretion.
